### PR TITLE
Ignore fixtures in lint

### DIFF
--- a/test-app/.eslintignore
+++ b/test-app/.eslintignore
@@ -23,3 +23,6 @@
 /package.json.ember-try
 /package-lock.json.ember-try
 /yarn.lock.ember-try
+
+# fixtures
+tests/**/fixtures/


### PR DESCRIPTION
It is not enough to `/* eslint-disable */` fixture files — they're large and cause a timeout in lint jobs.

This commit adds fixtures in the `tests/` folder in `test-app`, ignoring fixtures, unblocking the lint CI job.